### PR TITLE
Relative paths resolve from Karma basePath

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 var wiredep = require('wiredep');
+var path    = require("path");
 
 function createPattern(path) {
   return {pattern: path, included: true, served: true, watched: false};
 }
 
-importDependencies.$inject = ['config.files', 'config.wiredep'];
-function importDependencies(files, options) {
+importDependencies.$inject = ['config.files', 'config.wiredep', 'config.basePath'];
+function importDependencies(files, options, basePath) {
+  options.cwd = path.resolve(basePath, options.cwd);  // Relative paths resolve from Karma basePath
   wiredep(options).js.slice().reverse().forEach(function(dep) {
     files.unshift(createPattern(dep));
   });

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function createPattern(path) {
 
 importDependencies.$inject = ['config.files', 'config.wiredep', 'config.basePath'];
 function importDependencies(files, options, basePath) {
-  options.cwd = path.resolve(basePath, options.cwd);  // Relative paths resolve from Karma basePath
+  options.cwd = path.resolve(basePath, options.cwd || '');  // Relative paths resolve from Karma basePath
   wiredep(options).js.slice().reverse().forEach(function(dep) {
     files.unshift(createPattern(dep));
   });


### PR DESCRIPTION
Love this plugin. I needed to point to bower.json which is at the top
of the project. This change makes wiredep resolve relative paths using
the Karma basePath.
