### PR TITLE
handle absent option field in karma.conf.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function createPattern(path) {
 
 importDependencies.$inject = ['config.files', 'config.wiredep', 'config.basePath'];
 function importDependencies(files, options, basePath) {
+  options = options || {};
   options.cwd = path.resolve(basePath, options.cwd || '');  // Relative paths resolve from Karma basePath
   wiredep(options).js.slice().reverse().forEach(function(dep) {
     files.unshift(createPattern(dep));


### PR DESCRIPTION
```
TypeError: Cannot read property 'cwd' of undefined
    at importDependencies (.../node_modules/karma-wiredep/index.js:10:47)
```
